### PR TITLE
Upgrade scallop

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ easy-fcrepo-validate-checkums
 
 Validate the checksums of a Fedora Commons Repository's datastreams.
 
+
 SYNOPSIS
 --------
 
@@ -13,6 +14,7 @@ SYNOPSIS
         -p <fcrepo-password> ] \
        [-l][-s] \
        [-t <time-between-calls>] \
+
 
 DESCRIPTION
 -----------
@@ -25,15 +27,18 @@ action of recording a log message causes Fedora to update the datastream's check
 recorded. It will however be written to the error log. It is of course advisable to configure the smtp appender of the 
 logger configuration to send an e-mail to responsible staff to warn them about the checksum mismatch.
 
+
 ARGUMENTS
 ---------
 
-* ``--fcrepo-server``, ``-f`` -- URL of the Fedora Commons Repository Server
-* ``--fcrepo-user``, ``-u`` -- Fedora user to connect with
-* ``--fcrepo-password``, ``-p`` -- Fedora user's password
-* ``--log-results``, ``-l`` -- whether to log the result of the validation in the digital object's audit log
-* ``--skip-external-datastreams``, ``-s`` -- whether to skip datastreams with control group ``R`` and ``E``.
-* ``--time-between-calls``, ``-t`` -- time in milliseconds to wait before doing the next call to Fedora
+    -p, --fcrepo-password  <arg>       (default = fedoraAdmin)
+    -f, --fcrepo-server  <arg>         (default = http://localhost:8080/fedora)
+    -u, --fcrepo-user  <arg>           (default = fedoraAdmin)
+    -l, --log-result
+    -s, --skip-external-datastreams
+    -t, --time-between-calls  <arg>    (default = 0)
+        --help                        Show help message
+        --version                     Show version of this program
 
 
 INSTALLATION AND CONFIGURATION

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.yourmediashelf.fedora.client</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.rogach</groupId>
             <artifactId>scallop_2.11</artifactId>
-            <version>1.0.1</version>
+            <version>2.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.yourmediashelf.fedora.client</groupId>

--- a/src/main/scala/nl/knaw/dans/easy/valchecksum/Conf.scala
+++ b/src/main/scala/nl/knaw/dans/easy/valchecksum/Conf.scala
@@ -22,6 +22,10 @@ import org.apache.commons.configuration.PropertiesConfiguration
 import org.rogach.scallop.ScallopConf
 
 class Conf(args: Seq[String]) extends ScallopConf(args) {
+
+  appendDefaultToDescription = true
+  editBuilder(_.setHelpWidth(110))
+
   val props = new PropertiesConfiguration(new File(homedir, "cfg/application.properties"))
   printedName = "easy-fcrepo-validate-checksums"
   version(s"$printedName ${Version()}")
@@ -42,4 +46,6 @@ class Conf(args: Seq[String]) extends ScallopConf(args) {
   val logResult = opt[Boolean]("log-result", short = 'l', default = Some(props.getBoolean("default.log-result")))
   val skipExternalDatastreams = opt[Boolean]("skip-external-datastreams", short = 's', default = Some(props.getBoolean("default.skip-external-datastreams")))
   val delay = opt[Int]("time-between-calls", short = 't', default = Some(props.getInt("default.time-between-calls")))
+
+  verify()
 } 


### PR DESCRIPTION
fixes EASY-1049 Upgrade scallop
#### When applied it will
- use the version 1.0.1 of scallop
#### Where should the reviewer @DANS-KNAW/easy start?

Conf   pom
#### How should this be manually tested?
- execute ./run.sh --help (provide first the app.home, see https://github.com/DANS-KNAW/easy-dtap#running-a-new-component)
#### related pull requests on github

| repo | PR |
| --- | --- |
| easy- | [PR#](PRlink) |
